### PR TITLE
Fragment depth function

### DIFF
--- a/src/Graphics/GPipe/Stream/Fragment.hs
+++ b/src/Graphics/GPipe/Stream/Fragment.hs
@@ -44,6 +44,7 @@ module Graphics.GPipe.Stream.Fragment (
     dFdy,
     fwidth,
     filterFragments,
+    fragDepth,
 
     -- * Creating fragment streams
     VertexOutput(..),

--- a/src/Shader.hs
+++ b/src/Shader.hs
@@ -30,6 +30,7 @@ module Shader (
     dFdx,
     dFdy,
     fwidth,
+    fragDepth,
     sampleBinFunc,
     sampleTernFunc,
     module Data.Boolean


### PR DESCRIPTION
I've found that there is no way to get fragment depth in fragment shader. It is particular impossible to use frame buffer with depth without fragment depth function.

Value is acquired from "gl_FragCoord.z" with new helper function.
